### PR TITLE
Refactor permission loading into UserService

### DIFF
--- a/app/Controllers/Auth.php
+++ b/app/Controllers/Auth.php
@@ -146,10 +146,6 @@ class Auth extends Controller
             return redirect()->back()->with('error', 'Email atau password salah.');
         }
 
-        // ✅ Baru aman dipanggil di sini
-        $permissions = $this->userService->getPermissionsByUserId($login['id']);
-        session()->set('user_permissions', $permissions);
-
         return redirect()->to('/')->with('success', 'Login berhasil!');
     }
 

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -166,13 +166,11 @@ class UserService
             return 'not_active';
         }
 
-        $userPermissions = $this->getUserPermissions($user['role_id']);
+        $rolePermissions = $this->getUserPermissions($user['role_id']);
+        $rolePermissionNames = array_column($rolePermissions, 'permission_name');
 
-        if (!empty($userPermissions) && is_array($userPermissions) && isset($userPermissions[0]) && is_array($userPermissions[0])) {
-            $userPermissions = array_map(fn($p) => (object) $p, $userPermissions);
-        }
-
-        $userPermissionNames = array_map(fn($p) => $p->permission_name, $userPermissions);
+        $userSpecificPermissions = $this->getPermissionsByUserId($user['id']);
+        $userPermissionNames = array_values(array_unique(array_merge($rolePermissionNames, $userSpecificPermissions)));
 
         $this->session->set([
             'user_id'    => $user['id'],
@@ -371,17 +369,16 @@ class UserService
     }
 
     public function getPermissionsByUserId(int $userId): array
-{
-    $repo = new \App\Repositories\UserRepository();
-    $permissions = $repo->getUserPermissions($userId);
-    return array_column($permissions, 'permission_name');
-}
+    {
+        $permissions = $this->userRepo->getUserPermissions($userId);
+        return array_column($permissions, 'permission_name');
+    }
 
-public function getRoleIdBySlug(string $slug): ?int
-{
-    $role = model('RoleModel')->where('slug', $slug)->first();
-    return $role['id'] ?? null;
-}
+    public function getRoleIdBySlug(string $slug): ?int
+    {
+        $role = model('RoleModel')->where('slug', $slug)->first();
+        return $role['id'] ?? null;
+    }
 
 
 }


### PR DESCRIPTION
## Summary
- simplify Auth controller by removing redundant permission fetching
- load role and user-specific permissions within UserService::loginUser and store them in session

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688df4f9c6008320b37189c7c74331a2