### PR TITLE
Validate numeric IDs in region API endpoints

### DIFF
--- a/app/Controllers/Api/Region.php
+++ b/app/Controllers/Api/Region.php
@@ -41,7 +41,9 @@ class Region extends BaseController
 
     public function districts($regencyId = null)
     {
-        if (!$regencyId) return $this->failValidationError('ID kabupaten/kota tidak boleh kosong.');
+        if (!$regencyId || !is_numeric($regencyId)) {
+            return $this->failValidationError('ID kabupaten/kota tidak valid.');
+        }
 
         $model = new DistrictModel();
         return $this->respond(
@@ -51,7 +53,9 @@ class Region extends BaseController
 
     public function villages($districtId = null)
     {
-        if (!$districtId) return $this->failValidationError('ID kecamatan tidak boleh kosong.');
+        if (!$districtId || !is_numeric($districtId)) {
+            return $this->failValidationError('ID kecamatan tidak valid.');
+        }
 
         $model = new VillageModel();
         return $this->respond(


### PR DESCRIPTION
## Summary
- ensure districts and villages endpoints validate numeric IDs and return `failValidationError` for invalid input

## Testing
- `phpdbg -qrr vendor/bin/phpunit` *(warns: No code coverage driver available)*

------
https://chatgpt.com/codex/tasks/task_e_688df50afc5c8320baa18270e192e42d