### PR TITLE
Add tests for auth and inventory services

### DIFF
--- a/tests/unit/InventoryServiceTest.php
+++ b/tests/unit/InventoryServiceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Services;
+use App\Services\InventoryService;
+use App\Repositories\InventoryRepository;
+
+final class InventoryServiceTest extends CIUnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Services::reset();
+        session()->set('user_id', 99);
+    }
+
+    public function testIncreaseStockUpdatesRepositoryAndLogs(): void
+    {
+        $repo = new class extends InventoryRepository {
+            public array $updateArgs;
+            public array $logData;
+            public function __construct() {}
+            public function updateStock($warehouseId, $productId, $quantity)
+            {
+                $this->updateArgs = func_get_args();
+            }
+            public function insertLog($data)
+            {
+                $this->logData = $data;
+            }
+        };
+
+        $service = new InventoryService($repo);
+        $service->increaseStock(1, 2, 5, 'test');
+
+        $this->assertSame([1, 2, 5], $repo->updateArgs);
+        $this->assertSame(99, $repo->logData['user_id']);
+        $this->assertSame('in', $repo->logData['type']);
+        $this->assertSame(5, $repo->logData['quantity']);
+        $this->assertSame('test', $repo->logData['note']);
+    }
+
+    public function testDecreaseStockUpdatesRepositoryAndLogs(): void
+    {
+        $repo = new class extends InventoryRepository {
+            public array $updateArgs;
+            public array $logData;
+            public function __construct() {}
+            public function updateStock($warehouseId, $productId, $quantity)
+            {
+                $this->updateArgs = func_get_args();
+            }
+            public function insertLog($data)
+            {
+                $this->logData = $data;
+            }
+        };
+
+        $service = new InventoryService($repo);
+        $service->decreaseStock(1, 2, 3, 'less');
+
+        $this->assertSame([1, 2, -3], $repo->updateArgs);
+        $this->assertSame(99, $repo->logData['user_id']);
+        $this->assertSame('out', $repo->logData['type']);
+        $this->assertSame(3, $repo->logData['quantity']);
+        $this->assertSame('less', $repo->logData['note']);
+    }
+}
+

--- a/tests/unit/UserServiceTest.php
+++ b/tests/unit/UserServiceTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Services;
+use App\Services\UserService;
+
+final class UserServiceTest extends CIUnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Services::reset();
+    }
+
+    public function testRegisterUserHashesPasswordAndSendsEmail(): void
+    {
+        $repo = new class {
+            public array $data;
+            public function createUser($data)
+            {
+                $this->data = $data;
+                return true;
+            }
+        };
+
+        $service = new class($repo) extends UserService {
+            public bool $emailSent = false;
+            public function __construct($repo)
+            {
+                $this->userRepo = $repo;
+                $this->session = Services::session();
+            }
+            public function sendActivationEmail($email, $activationCode)
+            {
+                $this->emailSent = true;
+            }
+        };
+
+        $data = [
+            'name' => 'Tester',
+            'email' => 'tester@example.com',
+            'password' => 'secret',
+        ];
+
+        $result = $service->registerUser($data);
+
+        $this->assertTrue($result);
+        $this->assertTrue(password_verify('secret', $repo->data['password']));
+        $this->assertSame(0, $repo->data['is_active']);
+        $this->assertArrayHasKey('activation_code', $repo->data);
+        $this->assertTrue($service->emailSent);
+    }
+
+    public function testLoginUserSetsSessionAndReturnsUser(): void
+    {
+        $hashed = password_hash('secret', PASSWORD_BCRYPT);
+
+        $repo = new class($hashed) {
+            private string $password;
+            public function __construct($password)
+            {
+                $this->password = $password;
+            }
+            public function getUserWithRoleSlugByEmail($email)
+            {
+                return [
+                    'id' => 1,
+                    'name' => 'Tester',
+                    'email' => $email,
+                    'password' => $this->password,
+                    'role_id' => 1,
+                    'role_name' => 'Admin',
+                    'role_slug' => 'admin',
+                    'is_active' => 1,
+                ];
+            }
+            public function getUserPermissions($roleId)
+            {
+                return [['permission_name' => 'manage_all']];
+            }
+            public function getAllPermissions()
+            {
+                return [['permission_name' => 'manage_all']];
+            }
+            public function updateUser($id, $data)
+            {
+                // no-op
+            }
+        };
+
+        $service = new class($repo) extends UserService {
+            public function __construct($repo)
+            {
+                $this->userRepo = $repo;
+                $this->session = Services::session();
+            }
+            public function sendActivationEmail($email, $activationCode)
+            {
+                // noop
+            }
+        };
+
+        $result = $service->loginUser('tester@example.com', 'secret');
+
+        $this->assertIsArray($result);
+        $this->assertSame(1, session()->get('user_id'));
+        $this->assertTrue(session()->get('is_logged_in'));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests verifying registration hashes passwords and sends activation email
- ensure login stores session data for authenticated users
- cover inventory service stock adjustments and logging

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688df518241083209eae56b0a8443860