### PR TITLE
Remove unused ProductFormatter imports

### DIFF
--- a/app/Controllers/MarketplaceTransaction.php
+++ b/app/Controllers/MarketplaceTransaction.php
@@ -18,7 +18,6 @@ use App\Models\ProductModel;
 use PhpOffice\PhpSpreadsheet\Shared\Date as ExcelDate;
 use CodeIgniter\I18n\Time;
 use App\Models\BrandModel;
-use App\Helpers\ProductFormatter;
 use CodeIgniter\API\ResponseTrait;
 
 

--- a/app/Services/MarketplaceTransactionService.php
+++ b/app/Services/MarketplaceTransactionService.php
@@ -3,7 +3,6 @@
 namespace App\Services;
 
 use App\Repositories\MarketplaceTransactionRepository;
-use App\Helpers\ProductFormatter;
 
 /**
  * Service Layer untuk Marketplace Transaction


### PR DESCRIPTION
## Summary
- drop unused ProductFormatter import from MarketplaceTransaction controller
- remove ProductFormatter import from MarketplaceTransaction service

## Testing
- `./vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688f433fffac83208ee972021d56e822