### PR TITLE
Merge all-platform transaction pagination

### DIFF
--- a/app/Controllers/MarketplaceTransaction.php
+++ b/app/Controllers/MarketplaceTransaction.php
@@ -81,7 +81,7 @@ public function getDataAll(): ResponseInterface
             'platform'     => 'all'
         ];
 
-        $data = $this->service->getPaginatedTransactionsAll($params);
+        $data = $this->service->getPaginatedTransactions($params);
         return $this->response->setJSON($data);
     } catch (\Throwable $e) {
         log_message('error', '[MarketplaceTransaction::getDataAll] ' . $e->getMessage());

--- a/app/Repositories/MarketplaceTransactionRepository.php
+++ b/app/Repositories/MarketplaceTransactionRepository.php
@@ -167,43 +167,4 @@ public function getHistoricalSales(int $productId, string $startDate, string $en
     return array_map(fn($row) => (int)$row['total_qty'], $result);
 }
 
-// 📁 app/Repositories/MarketplaceTransactionRepository.php
-
-public function getBaseQueryAll(array $params): \CodeIgniter\Database\BaseBuilder
-{
-    $builder = $this->db->table('marketplace_transactions')
-        ->select('
-            marketplace_transactions.*, 
-            brands.brand_name, 
-            brands.primary_color,
-            users.name as processed_by_name
-        ')
-        ->join('brands', 'brands.id = marketplace_transactions.brand_id', 'left')
-        ->join('users', 'users.id = marketplace_transactions.processed_by', 'left')
-        ->orderBy('marketplace_transactions.date', 'desc');
-
-    // Filter brand
-    if (!empty($params['brand_id'])) {
-        $builder->where('marketplace_transactions.brand_id', $params['brand_id']);
-    }
-
-    // Filter tanggal
-    if (!empty($params['start_date']) && !empty($params['end_date'])) {
-        $builder->where('marketplace_transactions.date >=', $params['start_date']);
-        $builder->where('marketplace_transactions.date <=', $params['end_date']);
-    }
-
-    // Filter pencarian
-    if (!empty($params['search'])) {
-        $builder->groupStart()
-            ->like('marketplace_transactions.order_number', $params['search'])
-            ->orLike('marketplace_transactions.tracking_number', $params['search'])
-            ->orLike('brands.brand_name', $params['search'])
-            ->orLike('store_name', $params['search'])
-            ->groupEnd();
-    }
-
-    return $builder;
-}
-
 }

--- a/app/Services/MarketplaceTransactionService.php
+++ b/app/Services/MarketplaceTransactionService.php
@@ -147,12 +147,7 @@ class MarketplaceTransactionService
     $start = null;
     $end = null;
 
-    // ⛳ Kalau platform = 'all' pakai method khusus
-    if (strtolower($params['platform']) === 'all') {
-        return $this->getPaginatedTransactionsAll($params);
-    }
-
-    // 🔨 Base builder utama
+    // 🔨 Base builder utama (platform dapat berupa nama platform atau 'all')
     $builder = $this->repo->getBaseQuery($params['platform']);
 
     // 🎯 Filter by Brand
@@ -266,49 +261,6 @@ class MarketplaceTransactionService
 
         return implode('', $productDetails);
     }
-
-    // 📁 app/Services/MarketplaceTransactionService.php
-
-public function getPaginatedTransactionsAll(array $params): array
-{
-    try {
-        $builder = $this->repo->getBaseQueryAll($params);
-
-        $builderFiltered = clone $builder;
-        $recordsFiltered = $builderFiltered->countAllResults();
-
-        $data = $builder
-            ->limit((int) $params['length'], (int) $params['start'])
-            ->get()
-            ->getResultArray();
-
-        foreach ($data as &$row) {
-            $products = $this->repo->getTransactionProducts($row['id']);
-
-            $productStrings = array_map(function ($p) {
-                return "{$p['sku']}::{$p['nama_produk']}::{$p['quantity']}::{$p['hpp']}::{$p['unit_selling_price']}";
-            }, $products);
-
-            $row['products'] = $this->formatProducts(implode('||', $productStrings));
-            $row['processed_by'] = $row['processed_by_name'] ?? '-';
-        }
-
-        return [
-            'draw' => intval($params['draw']),
-            'recordsTotal' => $recordsFiltered,
-            'recordsFiltered' => $recordsFiltered,
-            'data' => $data
-        ];
-    } catch (\Throwable $e) {
-        log_message('error', '[MarketplaceTransactionService::getPaginatedTransactionsAll] ' . $e->getMessage());
-        return [
-            'draw' => $params['draw'] ?? 0,
-            'recordsTotal' => 0,
-            'recordsFiltered' => 0,
-            'data' => [],
-        ];
-    }
-}
 
 public function getStatisticsAll(array $filters): array
 {


### PR DESCRIPTION
## Summary
- support `platform = 'all'` directly in `getPaginatedTransactions`
- streamline repository base query by removing `getBaseQueryAll`
- update controller to use unified transaction pagination

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688f434b57508320892117b22aa7357e