### PR TITLE
Separate total and filtered counts

### DIFF
--- a/app/Services/MarketplaceTransactionService.php
+++ b/app/Services/MarketplaceTransactionService.php
@@ -234,6 +234,10 @@ class MarketplaceTransactionService
     // 🔨 Base builder utama (platform dapat berupa nama platform atau 'all')
     $builder = $this->repo->getBaseQuery($params['platform']);
 
+    // 🧮 Hitung seluruh data sebelum filter apapun diterapkan
+    $builderTotal  = clone $builder;
+    $recordsTotal  = $builderTotal->countAllResults();
+
     // 🎯 Filter by Brand
     if (!empty($params['brand_id'])) {
         $builder->where('transactions.brand_id', $params['brand_id']);
@@ -291,7 +295,7 @@ class MarketplaceTransactionService
 
     return [
         'draw'            => intval($params['draw']),
-        'recordsTotal'    => $recordsFiltered, // ✅ Bisa ganti ini kalau mau beda
+        'recordsTotal'    => $recordsTotal,
         'recordsFiltered' => $recordsFiltered,
         'data'            => $data
     ];


### PR DESCRIPTION
## Summary
- Compute total transaction count before filters and use it for `recordsTotal`
- Keep filtered count for `recordsFiltered`

## Testing
- `composer test` *(fails: No code coverage driver available)*

------
https://chatgpt.com/codex/tasks/task_e_688f88b42ee8832091663991889bfffd