### PR TITLE
Relax Content-Type check for Marketplace POST handling

### DIFF
--- a/app/Controllers/MarketplaceTransaction.php
+++ b/app/Controllers/MarketplaceTransaction.php
@@ -225,8 +225,8 @@ public function store(string $platform): ResponseInterface
             return $this->failMethodNotAllowed();
         }
         
-        // 3. Strict Content Type
-        if ($this->request->getHeaderLine('Content-Type') !== 'application/x-www-form-urlencoded') {
+        // 3. Content-Type Validation
+        if (strpos($this->request->getHeaderLine('Content-Type'), 'application/x-www-form-urlencoded') === false) {
             return $this->failUnsupportedMediaType();
         }
 


### PR DESCRIPTION
## Summary
- loosen Content-Type validation to accept common form URL encoded variants

## Testing
- `composer test` *(fails: No code coverage driver available)*
- `vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688f88b2418c832098ed8cab59133110