### PR TITLE
Add validation for missing Binderbyte API key

### DIFF
--- a/app/Controllers/MarketplaceTransaction.php
+++ b/app/Controllers/MarketplaceTransaction.php
@@ -856,6 +856,14 @@ public function trackResi()
 
     $apiKey = env('BINDERBYTE_API_KEY'); // pastikan sudah diset di .env
 
+    if (empty($apiKey)) {
+        log_message('error', '[MarketplaceTransaction::trackResi] BINDERBYTE_API_KEY is missing');
+        return $this->response->setJSON([
+            'status' => 'error',
+            'message' => 'API key Binderbyte tidak ditemukan.'
+        ])->setStatusCode(500);
+    }
+
     $url = "https://api.binderbyte.com/v1/track?api_key={$apiKey}&courier={$courier}&awb={$awb}";
 
     try {


### PR DESCRIPTION
## Summary
- ensure `trackResi` checks for missing `BINDERBYTE_API_KEY`

## Testing
- `composer test` *(fails: No code coverage driver available)*

------
https://chatgpt.com/codex/tasks/task_e_688f88b0649c8320b0c17aca3ab825be