### PR TITLE
Limit import row count to 4000

### DIFF
--- a/app/Controllers/MarketplaceTransaction.php
+++ b/app/Controllers/MarketplaceTransaction.php
@@ -417,8 +417,9 @@ public function importExcel(string $platform): ResponseInterface
             $spreadsheet = IOFactory::load($file->getTempName());
             $sheet = $spreadsheet->getActiveSheet();
             $rows = $sheet->toArray(null, true, true, true);
+	// TODO: consider streaming to avoid loading entire sheet into memory
 
-            if (count($rows) > 10000) {
+            if (count($rows) > 4000) {
                 return $this->respond([
                     'status' => 'error',
                     'errors' => ['Jumlah baris melebihi batas maksimum 4000 baris.']


### PR DESCRIPTION
## Summary
- enforce 4000 row limit when importing marketplace transactions
- note that sheet reading should be streamed to avoid loading entire file

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688f88ae21e08320aca08c4db0815e5a