### PR TITLE
chore: remove unused transaction helpers

### DIFF
--- a/app/Repositories/MarketplaceTransactionRepository.php
+++ b/app/Repositories/MarketplaceTransactionRepository.php
@@ -17,46 +17,6 @@ class MarketplaceTransactionRepository
         $this->db = Database::connect();
     }
 
-    /**
-     * Query builder untuk DataTables server-side
-     */
-    public function getTransactionQuery(array $filters, string $platform): BaseBuilder
-{
-    $builder = $this->db->table('marketplace_transactions mt')
-        ->select("
-            mt.id, mt.date, mt.order_number, mt.tracking_number, mt.store_name, mt.status,
-            mt.selling_price, mt.discount, mt.admin_fee, mt.hpp,
-            (mt.selling_price - (mt.discount + mt.admin_fee + mt.hpp)) as gross_profit,
-            b.brand_name, b.primary_color,
-            SUM(d.quantity) as total_qty
-        ")
-        ->join('marketplace_detail_transaction d', 'd.transaction_id = mt.id', 'left')
-        ->join('products p', 'p.id = d.product_id', 'left')
-        ->join('brands b', 'b.id = mt.brand_id', 'left')
-        ->where('mt.platform', $platform)
-        ->groupBy('mt.id');
-
-    if (!empty($filters['brand_id'])) {
-        $builder->where('mt.brand_id', $filters['brand_id']);
-    }
-
-    if (!empty($filters['start_date']) && !empty($filters['end_date'])) {
-        $builder->where("DATE(mt.date) >=", $filters['start_date']);
-        $builder->where("DATE(mt.date) <=", $filters['end_date']);
-    }
-
-    if (!empty($filters['search'])) {
-        $builder->groupStart()
-            ->like('mt.order_number', $filters['search'])
-            ->orLike('mt.tracking_number', $filters['search'])
-            ->orLike('mt.store_name', $filters['search'])
-            ->orLike('p.nama_produk', $filters['search'])
-            ->orLike('b.brand_name', $filters['search'])
-            ->groupEnd();
-    }
-
-    return $builder;
-}
 
 public function getBaseQuery(?string $platform = null): \CodeIgniter\Database\BaseBuilder
 {

--- a/app/Services/MarketplaceTransactionService.php
+++ b/app/Services/MarketplaceTransactionService.php
@@ -219,22 +219,6 @@ class MarketplaceTransactionService
 }
 
 
-    private function applyDateFilter($builder, array $params)
-{
-    if ($params['jenis_filter'] === 'periode' && !empty($params['periode'])) {
-        [$start, $end] = get_date_range_from_periode($params['periode']);
-        if ($start && $end) {
-            $builder->where('transactions.date >=', $start);
-            $builder->where('transactions.date <=', $end);
-        }
-    } elseif ($params['jenis_filter'] === 'custom' && !empty($params['start_date']) && !empty($params['end_date'])) {
-        $builder->where('transactions.date >=', $params['start_date']);
-        $builder->where('transactions.date <=', $params['end_date']);
-    }
-    
-    return $builder;
-}
-
     /**
      * 🧩 Format Produk ke HTML
      */


### PR DESCRIPTION
## Summary
- drop unused getTransactionQuery in marketplace transaction repository
- remove dead applyDateFilter helper from transaction service

## Testing
- `./vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688f434d6694832080ec0a3929265069