### PR TITLE
Support platform-specific validation for marketplace transactions

### DIFF
--- a/app/Services/MarketplaceTransactionService.php
+++ b/app/Services/MarketplaceTransactionService.php
@@ -31,15 +31,39 @@ class MarketplaceTransactionService
     /**
      * ✅ Rules Validasi
      */
-    public function getValidationRules(): array
+    public function getValidationRules(?string $platform = null): array
     {
-        return [
+        $rules = [
             'order_number'  => 'required|string|max_length[100]',
             'date'          => 'required|valid_date',
             'brand_id'      => 'required|numeric',
             'selling_price' => 'required|decimal',
             'hpp'           => 'required|decimal',
         ];
+
+        if (! empty($platform)) {
+            $platform = strtolower($platform);
+            $platformRules = [
+                'shopee' => [
+                    'tracking_number' => 'required|string|max_length[100]',
+                ],
+                'tokopedia' => [
+                    'tracking_number' => 'required|string|max_length[100]',
+                ],
+                'lazada' => [
+                    'tracking_number' => 'required|string|max_length[100]',
+                ],
+                'tiktokshop' => [
+                    'tracking_number' => 'required|string|max_length[100]',
+                ],
+            ];
+
+            if (isset($platformRules[$platform])) {
+                $rules = array_merge($rules, $platformRules[$platform]);
+            }
+        }
+
+        return $rules;
     }
 
     /**

--- a/tests/unit/MarketplaceTransactionServiceTest.php
+++ b/tests/unit/MarketplaceTransactionServiceTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use CodeIgniter\Test\CIUnitTestCase;
+use App\Services\MarketplaceTransactionService;
+
+final class MarketplaceTransactionServiceTest extends CIUnitTestCase
+{
+    public function testPlatformSpecificRuleApplied(): void
+    {
+        $service = new class extends MarketplaceTransactionService
+        {
+            public function __construct() {}
+        };
+
+        $rules = $service->getValidationRules('shopee');
+
+        $this->assertArrayHasKey('tracking_number', $rules);
+    }
+}


### PR DESCRIPTION
## Summary
- allow MarketplaceTransactionService::getValidationRules to accept a platform parameter and merge platform-specific rules
- add unit test covering platform-specific rule merge

## Testing
- `vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688f441221708320bf44222abdc47743