### PR TITLE
Validate Content-Type header before processing marketplace transactions

### DIFF
--- a/app/Controllers/MarketplaceTransaction.php
+++ b/app/Controllers/MarketplaceTransaction.php
@@ -259,8 +259,13 @@ public function store(string $platform): ResponseInterface
         }
         
         // 3. Strict Content Type
-        if (!$this->request->hasHeader('Content-Type', 'application/x-www-form-urlencoded')) {
-            return $this->failUnsupportedMediaType();
+        if (
+            $this->request->getHeaderLine('Content-Type') !== 'application/x-www-form-urlencoded'
+        ) {
+            return $this->fail(
+                'Unsupported Media Type',
+                ResponseInterface::HTTP_UNSUPPORTED_MEDIA_TYPE
+            );
         }
 
         // 4. Input Processing

--- a/tests/unit/MarketplaceTransactionStoreTest.php
+++ b/tests/unit/MarketplaceTransactionStoreTest.php
@@ -1,0 +1,33 @@
+<?php
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Services;
+use App\Controllers\MarketplaceTransaction;
+
+if (!function_exists('auth')) {
+    function auth()
+    {
+        return new class {
+            public function userHasPermission(string $permission): bool
+            {
+                return true;
+            }
+        };
+    }
+}
+
+final class MarketplaceTransactionStoreTest extends CIUnitTestCase
+{
+    public function testStoreRejectsWrongContentType(): void
+    {
+        $request = Services::request();
+        $request->setMethod('POST');
+        $request->setHeader('Content-Type', 'application/json');
+
+        $controller = new MarketplaceTransaction();
+        $controller->initController($request, Services::response(), Services::logger());
+
+        $response = $controller->store('tokopedia');
+
+        $this->assertSame(415, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `hasHeader` check with `getHeaderLine` comparison
- Handle unsupported media types with 415 response
- Cover invalid `Content-Type` header with unit test

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688f4413e3f48320bd0ee8b7f09a6fbf