### PR TITLE
Use binderbyte client service for tracking

### DIFF
--- a/app/Config/Services.php
+++ b/app/Config/Services.php
@@ -51,7 +51,8 @@ class Services extends BaseService
         public static function binderbyteClient()
 {
     $client = \Config\Services::curlrequest([
-        'baseURI' => 'https://api.binderbyte.com/',
+        'baseURI'    => 'https://api.binderbyte.com/',
+        'http_errors' => false,
     ]);
     return $client;
 }

--- a/app/Controllers/MarketplaceTransaction.php
+++ b/app/Controllers/MarketplaceTransaction.php
@@ -881,10 +881,10 @@ public function trackResi()
 
     $apiKey = env('BINDERBYTE_API_KEY'); // pastikan sudah diset di .env
 
-    $url = "https://api.binderbyte.com/v1/track?api_key={$apiKey}&courier={$courier}&awb={$awb}";
+    $url = "v1/track?api_key={$apiKey}&courier={$courier}&awb={$awb}";
 
     try {
-        $client = \Config\Services::curlrequest();
+        $client = service('binderbyteClient');
         $response = $client->get($url);
 
         $result = json_decode($response->getBody(), true);
@@ -930,7 +930,7 @@ public function trackResi()
 
       log_message('debug', '[🛠️ TRACKING UPDATE] Baris yang diupdate: ' . $model->db->affectedRows());
 
-      log_message('debug', '🔗 Request URL: ' . $url);
+      log_message('debug', '🔗 Request URL: https://api.binderbyte.com/' . $url);
         
 
         return $this->response->setJSON([


### PR DESCRIPTION
## Summary
- replace direct curlrequest calls with binderbyte client service
- configure binderbyte client with base URI and disabled HTTP errors

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688f44295a7883209b4349978f278a4e