### PR TITLE
feat: make import row limits configurable

### DIFF
--- a/app/Config/Constants.php
+++ b/app/Config/Constants.php
@@ -77,3 +77,12 @@ defined('EXIT_USER_INPUT')     || define('EXIT_USER_INPUT', 7);     // invalid u
 defined('EXIT_DATABASE')       || define('EXIT_DATABASE', 8);       // database error
 defined('EXIT__AUTO_MIN')      || define('EXIT__AUTO_MIN', 9);      // lowest automatically-assigned error code
 defined('EXIT__AUTO_MAX')      || define('EXIT__AUTO_MAX', 125);    // highest automatically-assigned error code
+
+// --------------------------------------------------------------------------
+// Import Excel Limits
+// --------------------------------------------------------------------------
+// These constants define the maximum number of rows allowed when importing
+// Excel files for various modules. Adjust these values to increase or
+// decrease the import limits without changing controller logic.
+defined('MAX_IMPORT_ROWS_SOSCOM') || define('MAX_IMPORT_ROWS_SOSCOM', 4000);
+defined('MAX_IMPORT_ROWS_MARKETPLACE') || define('MAX_IMPORT_ROWS_MARKETPLACE', 10000);

--- a/app/Controllers/MarketplaceTransaction.php
+++ b/app/Controllers/MarketplaceTransaction.php
@@ -450,10 +450,10 @@ public function importExcel(string $platform): ResponseInterface
             $sheet = $spreadsheet->getActiveSheet();
             $rows = $sheet->toArray(null, true, true, true);
 
-            if (count($rows) > 10000) {
+            if (count($rows) > MAX_IMPORT_ROWS_MARKETPLACE) {
                 return $this->respond([
                     'status' => 'error',
-                    'errors' => ['Jumlah baris melebihi batas maksimum 4000 baris.']
+                    'errors' => ['Jumlah baris melebihi batas maksimum ' . number_format(MAX_IMPORT_ROWS_MARKETPLACE, 0, ',', '.') . ' baris.']
                 ], 422);
             }
 

--- a/app/Controllers/SoscomTransaction.php
+++ b/app/Controllers/SoscomTransaction.php
@@ -102,8 +102,10 @@ public function index()
         $sheet = $spreadsheet->getActiveSheet();
         $rows = $sheet->toArray(null, true, true, true);
 
-        if (count($rows) > 4000) {
-            return $this->failValidationErrors(['Jumlah baris melebihi batas maksimum 4000.']);
+        if (count($rows) > MAX_IMPORT_ROWS_SOSCOM) {
+            return $this->failValidationErrors([
+                'Jumlah baris melebihi batas maksimum ' . number_format(MAX_IMPORT_ROWS_SOSCOM, 0, ',', '.') . '.'
+            ]);
         }
 
         $headerMap = [


### PR DESCRIPTION
## Summary
- add constants to configure Excel import limits
- use row-limit constants in Soscom and Marketplace import handlers
- align import error messages with configured limits

## Testing
- `composer test` *(fails: No code coverage driver available)*

------
https://chatgpt.com/codex/tasks/task_e_688f4422f9d08320a99a16c60728748b