### PR TITLE
refactor: delegate product formatting to helper

### DIFF
--- a/app/Controllers/MarketplaceTransaction.php
+++ b/app/Controllers/MarketplaceTransaction.php
@@ -82,6 +82,11 @@ public function getDataAll(): ResponseInterface
         ];
 
         $data = $this->service->getPaginatedTransactionsAll($params);
+
+        foreach ($data['data'] as &$row) {
+            $row['products'] = ProductFormatter::format($row['products']);
+        }
+
         return $this->response->setJSON($data);
     } catch (\Throwable $e) {
         log_message('error', '[MarketplaceTransaction::getDataAll] ' . $e->getMessage());
@@ -161,7 +166,11 @@ public function getStatisticsAll()
     
             // 🎯 Panggil service dengan param lengkap (termasuk filter)
             $data = $this->service->getPaginatedTransactions($params);
-    
+
+            foreach ($data['data'] as &$row) {
+                $row['products'] = ProductFormatter::format($row['products']);
+            }
+
             return $this->response->setJSON($data);
         } catch (\Exception $e) {
             log_message('error', '❌ Error getData(): ' . $e->getMessage());

--- a/app/Controllers/PurchaseOrder.php
+++ b/app/Controllers/PurchaseOrder.php
@@ -9,6 +9,7 @@ use App\Models\SupplierModel;
 use App\Models\ProductModel;
 use App\Services\InventoryService;
 use App\Repositories\InventoryRepository;
+use App\Helpers\ProductFormatter;
 
 
 class PurchaseOrder extends BaseController
@@ -180,6 +181,10 @@ public function getData()
         $params = $this->request->getPost(); // ✅ Harus POST
 
         $data = $this->service->getDataTable($params); // ⬅️ Pastikan ini DIKIRIM ke service
+
+        foreach ($data['data'] as &$row) {
+            $row['products'] = ProductFormatter::format($row['products']);
+        }
 
         return $this->response->setJSON(array_merge([
             csrf_token() => csrf_hash()

--- a/app/Helpers/ProductFormatter.php
+++ b/app/Helpers/ProductFormatter.php
@@ -4,14 +4,37 @@ namespace App\Helpers;
 
 class ProductFormatter
 {
+    /**
+     * Format array produk menjadi HTML terstruktur.
+     *
+     * @param array $products Daftar produk mentah
+     */
     public static function format(array $products): string
     {
-        $html = '<div class="product-list">';
-        foreach ($products as $product) {
-            $html .= '<div class="fw-semibold">' . esc($product['nama_produk']) . '</div>';
-            $html .= '<small class="text-muted">' . number_format($product['quantity']) . ' pcs × Rp ' . number_format($product['hpp'], 0, ',', '.') . '</small><br>';
+        if (empty($products)) {
+            return '-';
         }
-        $html .= '</div>';
+
+        $html = '';
+        foreach ($products as $product) {
+            $name  = esc($product['nama_produk'] ?? $product['name'] ?? '');
+            $qty   = number_format((int) ($product['quantity'] ?? 0), 0, ',', '.');
+            $priceValue = $product['unit_selling_price'] ?? $product['unit_price'] ?? $product['hpp'] ?? 0;
+            $price = number_format((float) $priceValue, 0, ',', '.');
+            $sku   = esc($product['sku'] ?? '');
+
+            $html .= "<div class='d-flex align-items-center mb-2'>";
+            $html .= "<div class='flex-grow-1'>";
+            $html .= "<div class='fw-medium'>{$name}</div>";
+            $html .= "<small class='text-muted'>{$qty} pcs × Rp {$price}</small>";
+            $html .= "</div>";
+
+            if ($sku !== '') {
+                $html .= "<span class='badge bg-light text-muted border ms-2'>{$sku}</span>";
+            }
+
+            $html .= "</div>";
+        }
 
         return $html;
     }

--- a/app/Services/MarketplaceTransactionService.php
+++ b/app/Services/MarketplaceTransactionService.php
@@ -3,7 +3,6 @@
 namespace App\Services;
 
 use App\Repositories\MarketplaceTransactionRepository;
-use App\Helpers\ProductFormatter;
 
 /**
  * Service Layer untuk Marketplace Transaction
@@ -201,12 +200,8 @@ class MarketplaceTransactionService
     foreach ($data as &$row) {
         $products = $this->repo->getTransactionProducts($row['id']);
 
-        $productStrings = array_map(function ($p) {
-            return "{$p['sku']}::{$p['nama_produk']}::{$p['quantity']}::{$p['hpp']}::{$p['unit_selling_price']}";
-        }, $products);
+        $row['products'] = $products;
 
-        $row['products'] = $this->formatProducts(implode('||', $productStrings));
-        
         $row['processed_by'] = $row['processed_by_name'] ?? '-';
     }
 
@@ -234,39 +229,6 @@ class MarketplaceTransactionService
     
     return $builder;
 }
-
-    /**
-     * 🧩 Format Produk ke HTML
-     */
-    public function formatProducts(string $products): string
-    {
-        if (empty($products)) return "-";
-
-        $productsArray = explode('||', $products);
-        $productDetails = [];
-
-        foreach ($productsArray as $productString) {
-            $parts = explode('::', $productString);
-            if (count($parts) >= 5) {
-                [$sku, $nama, $qty, , $unitPrice] = $parts;
-                $sku        = esc($sku);
-                $nama       = esc($nama);
-                $qty        = (int) $qty;
-                $unitPrice  = (float) $unitPrice;
-
-                $productDetails[] = "<div class='d-flex align-items-center mb-2'>
-                    <div class='flex-grow-1'>
-                        <div class='fw-medium'>{$nama}</div>
-                        <small class='text-muted'>" . number_format($qty, 0, ',', '.') . " pcs × Rp " . number_format($unitPrice, 0, ',', '.') . "</small>
-                    </div>
-                    <span class='badge bg-light text-muted border ms-2'>{$sku}</span>
-                </div>";
-            }
-        }
-
-        return implode('', $productDetails);
-    }
-
     // 📁 app/Services/MarketplaceTransactionService.php
 
 public function getPaginatedTransactionsAll(array $params): array
@@ -285,11 +247,7 @@ public function getPaginatedTransactionsAll(array $params): array
         foreach ($data as &$row) {
             $products = $this->repo->getTransactionProducts($row['id']);
 
-            $productStrings = array_map(function ($p) {
-                return "{$p['sku']}::{$p['nama_produk']}::{$p['quantity']}::{$p['hpp']}::{$p['unit_selling_price']}";
-            }, $products);
-
-            $row['products'] = $this->formatProducts(implode('||', $productStrings));
+            $row['products'] = $products;
             $row['processed_by'] = $row['processed_by_name'] ?? '-';
         }
 


### PR DESCRIPTION
## Summary
- move product rendering logic to `ProductFormatter` helper
- return raw product arrays from services
- format products in controllers before sending responses

## Testing
- `vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688f441f3250832081ffd1815d575c29